### PR TITLE
Fixed macros

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,7 @@
 
 /* USINGS */
 use core::panic::PanicInfo;
-#[macro_use]
-use ::retros::println;
+use retros::{print, println, setColourcode, clear, setCursor};
 
 /* REG PANIC HANDLER */
 #[cfg(not(test))]

--- a/src/vga_buffer.rs
+++ b/src/vga_buffer.rs
@@ -131,7 +131,7 @@ lazy_static! {
 /* MACROS */
 #[macro_export]
 macro_rules! print {
-	($($arg:tt)*) => ($crate::_print(format_args!($($arg)*)));
+	($($arg:tt)*) => ($crate::vga_buffer::_print(format_args!($($arg)*)));
 }
 
 #[macro_export]
@@ -142,12 +142,12 @@ macro_rules! println {
 
 #[macro_export]
 macro_rules! clear {
-	() => { $crate::_clear();};
+	() => { $crate::vga_buffer::_clear();};
 }
 
 #[macro_export]
 macro_rules! setCursor {
-	($col:tt,$row:tt) => { crate::vga_buffer::_set_cursor($row, $col);	};
+	($col:tt,$row:tt) => { $crate::vga_buffer::_set_cursor($row, $col);	};
 }
 
 #[macro_export]


### PR DESCRIPTION
Seems like the issues were:
* the whole path to the `_clear` and `_print` functions were not being provided in the macro definitions
* the `setCursor!` macro did not have `$` before `crate` in the path
* macros used in `main.rs` were not being imported

After fixing those issues, the VM seems to be running just fine :)